### PR TITLE
chore: Update copyright year range to 2024-2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2024 Daisuke Sato
+Copyright 2024-2026 Daisuke Sato
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ docker run --rm -it -v "${PWD}:/works" tiryoh/mcap-to-mp4 ./rosbag2_2024_02_18-2
 
 ## License
 
-Copyright 2024 Daisuke Sato
+Copyright 2024-2026 Daisuke Sato
 
 This repository is licensed under the MIT license, see [LICENSE](./LICENSE).  
 Unless attributed otherwise, everything in this repository is under the MIT license.
@@ -114,4 +114,3 @@ Unless attributed otherwise, everything in this repository is under the MIT lice
 
 * https://github.com/roboto-ai/robologs-ros-actions
 * https://github.com/mlaiacker/rosbag2video
-

--- a/mcap_to_mp4/cli.py
+++ b/mcap_to_mp4/cli.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # https://github.com/Tiryoh/mcap-to-mp4
-# Copyright 2024 Daisuke Sato <tiryoh@gmail.com>
+# Copyright 2024-2026 Daisuke Sato <tiryoh@gmail.com>
 # MIT License
 
 import argparse


### PR DESCRIPTION
## Summary
- update copyright notice from 2024 to 2024-2026 in LICENSE
- update copyright notice in README
- update module header comment in cli.py