### PR TITLE
feat: Add CompressedImage support

### DIFF
--- a/mcap_to_mp4/cli.py
+++ b/mcap_to_mp4/cli.py
@@ -38,8 +38,13 @@ def check_file_exists(file_path: os.PathLike) -> None:
 def get_image_topic_list(mcap_file_path: str) -> List[str]:
     topic_list = []
     with open(mcap_file_path, "rb") as f:
-        reader = make_reader(f, decoder_factories=[DecoderFactory()])
-        for schema, channel, message, ros_msg in reader.iter_decoded_messages():
+        reader = make_reader(f)
+        summary = reader.get_summary()
+        if summary is None:
+            return []
+        schemas = summary.schemas
+        for channel in summary.channels.values():
+            schema = schemas.get(channel.schema_id)
             if schema is not None and schema.name in IMAGE_SCHEMAS:
                 topic_list.append(channel.topic)
     return list(set(topic_list))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,15 +37,18 @@ def test_check_file_exists_invalid():
 
 
 def test_get_image_topic_list():
-    mock_reader = MagicMock()
     mock_schema = MagicMock()
     mock_schema.name = "sensor_msgs/msg/Image"
     mock_channel = MagicMock()
     mock_channel.topic = "/camera/image"
+    mock_channel.schema_id = 1
 
-    mock_reader.iter_decoded_messages.return_value = [
-        (mock_schema, mock_channel, None, None)
-    ]
+    mock_summary = MagicMock()
+    mock_summary.schemas = {1: mock_schema}
+    mock_summary.channels = {1: mock_channel}
+
+    mock_reader = MagicMock()
+    mock_reader.get_summary.return_value = mock_summary
 
     with patch('mcap_to_mp4.cli.make_reader', return_value=mock_reader):
         with patch('builtins.open', mock_open()):
@@ -101,15 +104,18 @@ def create_mock_compressed_ros_msg(height=480, width=640):
 
 
 def test_get_image_topic_list_compressed():
-    mock_reader = MagicMock()
     mock_schema = MagicMock()
     mock_schema.name = "sensor_msgs/msg/CompressedImage"
     mock_channel = MagicMock()
     mock_channel.topic = "/camera/image/compressed"
+    mock_channel.schema_id = 1
 
-    mock_reader.iter_decoded_messages.return_value = [
-        (mock_schema, mock_channel, None, None)
-    ]
+    mock_summary = MagicMock()
+    mock_summary.schemas = {1: mock_schema}
+    mock_summary.channels = {1: mock_channel}
+
+    mock_reader = MagicMock()
+    mock_reader.get_summary.return_value = mock_summary
 
     with patch('mcap_to_mp4.cli.make_reader', return_value=mock_reader):
         with patch('builtins.open', mock_open()):


### PR DESCRIPTION
## Summary
- Add support for `sensor_msgs/msg/CompressedImage` (JPEG/PNG) in addition to raw `sensor_msgs/msg/Image`
- Decode compressed images via `PIL.Image.open()` instead of raw buffer reshape
- Show CompressedImage topics in the topic list
- Ref #42

## How to test

Install this branch directly with uv:

```bash
uv tool install git+https://github.com/Tiryoh/mcap-to-mp4.git@feat/compressed-image-support
```

Or add to an existing environment:

```bash
uv pip install git+https://github.com/Tiryoh/mcap-to-mp4.git@feat/compressed-image-support
```

Then convert a CompressedImage topic:

```bash
mcap-to-mp4 input.mcap -t /camera/image/compressed -o output.mp4
```

## Test plan
- [x] All existing tests pass (9/9)
- [x] Verify with a real mcap file containing CompressedImage (JPEG) data

🤖 Generated with [Claude Code](https://claude.com/claude-code)