### PR TITLE
chore: Add pre-push hooks with prek

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+repos:
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.1.2
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          - flake8-isort
+          - flake8-unused-arguments
+        stages: [pre-push]
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.14.1
+    hooks:
+      - id: mypy
+        additional_dependencies: []
+        args: ["--config-file", ".mypy.ini"]
+        stages: [pre-push]
+
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: uv run pytest tests
+        language: system
+        pass_filenames: false
+        types: [python]
+        stages: [pre-push]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,49 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+mcap-to-mp4 is a Python CLI tool that converts ROS 2 rosbag2 recordings (MCAP format) to MP4 video files. It does not require a ROS 2 runtime.
+
+## Commands
+
+```bash
+# Install dependencies (dev)
+uv sync --group dev
+
+# Run the tool
+uv run mcap-to-mp4 <path_to_mcap> -t <topic_name> -o <output.mp4>
+
+# Run tests
+uv run pytest tests
+
+# Lint
+uv run flake8 .
+
+# Type check
+uv run mypy --config-file .mypy.ini .
+
+# Run all pre-push checks (flake8, mypy, pytest)
+prek run --all-files --stage pre-push
+
+# Install pre-push hook (first time setup)
+prek install --hook-type pre-push
+```
+
+## Architecture
+
+The codebase is a single-module CLI tool in `mcap_to_mp4/cli.py`:
+
+- **`parse_arguments()`** — argparse setup for `input`, `-t/--topic`, `-o/--output`
+- **`get_image_topic_list()`** — scans MCAP file for `sensor_msgs/msg/Image` and `sensor_msgs/msg/CompressedImage` topics
+- **`convert_to_mp4()`** — reads MCAP messages, decodes image frames (handling BGR8→RGB conversion for uncompressed, PIL decompression for compressed), calculates FPS from mean timestamp intervals, writes MP4 via imageio/ffmpeg
+
+Entry point: `mcap-to-mp4` → `mcap_to_mp4.cli:main`
+
+## Code Style
+
+- Max line length: 99 (configured in `.flake8`)
+- Google import order style (flake8-isort)
+- MyPy with `ignore_missing_imports = True`
+- Python 3.10+, managed with uv (hatchling build backend)

--- a/mcap_to_mp4/cli.py
+++ b/mcap_to_mp4/cli.py
@@ -4,19 +4,18 @@
 # MIT License
 
 import argparse
+import io
 import os
 import sys
+from statistics import mean
 from typing import List
-
-import io
 
 import imageio
 import mcap
+import numpy as np
 from mcap.reader import make_reader
 from mcap_ros2.decoder import DecoderFactory
-import numpy as np
 from PIL import Image
-from statistics import mean
 
 IMAGE_SCHEMAS = {"sensor_msgs/msg/Image", "sensor_msgs/msg/CompressedImage"}
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,8 +2,8 @@ import io
 from unittest.mock import MagicMock, mock_open, patch
 
 import numpy as np
-from PIL import Image
 import pytest
+from PIL import Image
 
 from mcap_to_mp4.cli import (check_file_exists, convert_to_mp4,
                              get_image_topic_list, parse_arguments)


### PR DESCRIPTION
## Summary
- Add `.pre-commit-config.yaml` with flake8, mypy, and pytest hooks (pre-push stage)
- Fix isort import ordering in `mcap_to_mp4/cli.py` and `tests/test_cli.py`
- Update `CLAUDE.md` with prek setup/run commands

## Test plan
- [x] `prek run --all-files --stage pre-push` passes all checks (flake8, mypy, pytest)
- [x] Pre-push hook fires on `git push` and all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)