### PR TITLE
fix: Restrict bump-version workflow to repository owner

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   bump-version:
     runs-on: ubuntu-latest
-    if: startsWith(github.event.issue.title, 'Release ')
+    if: startsWith(github.event.issue.title, 'Release ') && github.event.issue.user.login == github.repository_owner
     steps:
       - name: Install git-chglog
         run: |


### PR DESCRIPTION
## Summary
- Add `github.event.issue.user.login == github.repository_owner` condition to the bump-version workflow so it only runs when the issue is created by the repository owner

## Test plan
- [ ] Verify the workflow triggers when the repository owner creates a "Release ..." issue
- [ ] Verify the workflow does not trigger when a non-owner creates a "Release ..." issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)