### PR TITLE
fix: Add zero-division guards and thread safety to conversion pipeline

### DIFF
--- a/mcap_to_mp4/cli.py
+++ b/mcap_to_mp4/cli.py
@@ -22,7 +22,7 @@ from PIL import Image
 
 IMAGE_SCHEMAS = {"sensor_msgs/msg/Image", "sensor_msgs/msg/CompressedImage"}
 MEMORY_CHECK_INTERVAL = 100
-BYTES_PER_KB = 1024
+KB_PER_MB = 1024
 BYTES_PER_MB = 1024 * 1024
 
 
@@ -177,7 +177,7 @@ def convert_to_mp4(input_file, topic, output_file) -> None:
             if sys.platform == 'darwin':
                 return rss / BYTES_PER_MB
             else:
-                return rss / BYTES_PER_KB
+                return rss / KB_PER_MB
         except (ValueError, OSError, ImportError):
             return None
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -167,6 +167,31 @@ def test_convert_to_mp4_compressed_image():
         assert mock_writer.append_data.call_count == 3
 
 
+def test_convert_to_mp4_identical_timestamps():
+    mock_schema = MagicMock()
+    mock_schema.name = "sensor_msgs/msg/Image"
+
+    same_time = 1000000
+    messages = [
+        (
+            mock_schema,
+            MagicMock(topic="/camera/image"),
+            MagicMock(log_time=same_time),
+            create_mock_ros_msg()
+        )
+        for _ in range(3)
+    ]
+
+    mock_writer = MagicMock()
+
+    with patch('mcap_to_mp4.cli.make_reader', side_effect=setup_two_pass_reader(messages)), \
+            patch('mcap_to_mp4.cli.imageio.get_writer', return_value=mock_writer), \
+            patch('builtins.open', mock_open()):
+
+        with pytest.raises(SystemExit, match="1"):
+            convert_to_mp4("dummy.mcap", "/camera/image", "output.mp4")
+
+
 def test_convert_to_mp4_fps():
     # MagicMock(name=)とするとMagicMockオブジェクト自体の識別用の名前を設定してしまう
     mock_schema = MagicMock()


### PR DESCRIPTION
## Summary
- Move `MEMORY_CHECK_INTERVAL` to module level alongside `IMAGE_SCHEMAS`
- Extract `BYTES_PER_KB` / `BYTES_PER_MB` constants to replace magic numbers
- Guard `print_progress_bar()` against zero division when `total` is 0
- Replace backslash line continuations with parenthesized expressions (2 places)
- Guard against zero division when all timestamps are identical (FPS calculation)
- Make `Spinner.count` thread-safe with `threading.Lock` + property

## Test plan
- [x] `uv run flake8 mcap_to_mp4/ tests/` — passed
- [x] `uv run mypy --config-file .mypy.ini mcap_to_mp4/ tests/` — passed
- [x] `uv run pytest tests` — 9 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)