### PR TITLE
ci: Add uv lock step to bump-version workflow

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -24,6 +24,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: '0'
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
       - name: Create release branch
         id: create-release
         run: |
@@ -34,6 +36,7 @@ jobs:
           export BRANCH=release/v$VERSION
           bash .github/scripts/update_changelog.sh $VERSION
           bash .github/scripts/update_version.sh $VERSION
+          uv lock
           git switch -c $BRANCH
           git add .
           git commit -m "release: Release v$VERSION"

--- a/uv.lock
+++ b/uv.lock
@@ -274,7 +274,7 @@ wheels = [
 
 [[package]]
 name = "mcap-to-mp4"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "imageio", extra = ["ffmpeg"] },


### PR DESCRIPTION
## Summary
- Add `astral-sh/setup-uv@v5` and `uv lock` step to bump-version workflow
- Ensures the lockfile is automatically updated after version bump, preventing `uv sync --locked` failures
- Also fix `uv.lock` that was left out of sync after v0.4.0 release (0.3.0 → 0.4.0)

Fixes: https://github.com/Tiryoh/mcap-to-mp4/actions/runs/22253769431/job/64381627145

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Verify next release via bump-version workflow includes an updated `uv.lock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)